### PR TITLE
Prevent stacking autocmds on re-source

### DIFF
--- a/plugin/save-cursor-position.vim
+++ b/plugin/save-cursor-position.vim
@@ -1,6 +1,10 @@
 
-" Start the cursor from where you last left off in the file
-autocmd BufReadPost * call s:SetCursorPosition()
+augroup vimSaveCursorPosition
+  au!
+  " Start the cursor from where you last left off in the file
+  autocmd BufReadPost * call s:SetCursorPosition()
+au END
+
 function! s:SetCursorPosition()
   if &filetype !~ 'svn\|commit\c'
     if line("'\"") > 0 && line("'\"") <= line("$")


### PR DESCRIPTION
Put the autocmd in an augroup.

Otherwise if someone sources their vimrc again it will keep adding the same autocmd over and over.

Alternatively the plugin could check if it was loaded already and finish early. But for a plugin this small I think that's overkill.